### PR TITLE
CircleCI to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,12 @@ jobs:
                 command: |
                     cmake -DSTDLIB=libstdc++ \
                           -DCMAKE_BUILD_TYPE=Release  ..
+                    make test-candas
             - run:
-                name: "Building tests ..."
+                name: "Run tests ..."
                 working_directory: build
                 command: |
-                    make test-candas
+                    tests/test-candas
 
 workflows:
     version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,72 @@
+
+version: 2
+
+jobs:
+    test-gcc:
+        docker:
+            - image: candas/test-env:gcc
+        working_directory: ~/candas
+        steps:
+            - checkout
+            - run: git submodule update --init
+            - run: mkdir build
+            - run:
+                name: "Building tests ..."
+                working_directory: build
+                command: |
+                    cmake -DSTDLIB=libstdc++ \
+                          -DCMAKE_BUILD_TYPE=Release  ..
+                    make test-candas
+            - run:
+                name: "Run tests ..."
+                working_directory: build
+                command: |
+                    tests/test-candas
+    test-clang:
+        docker:
+            - image: candas/test-env:clang
+        working_directory: ~/candas
+        steps:
+            - checkout
+            - run: git submodule update --init
+            - run: mkdir build
+            - run:
+                name: "Building tests ..."
+                working_directory: build
+                command: |
+                    cmake -DSTDLIB=libstdc++ \
+                          -DCMAKE_BUILD_TYPE=Release  ..
+                    make test-candas
+            - run:
+                name: "Run tests ..."
+                working_directory: build
+                command: |
+                    tests/test-candas
+    test-clang-libcxx:
+        docker:
+            - image: candas/test-env:clang-libcxx
+        working_directory: ~/candas
+        steps:
+            - checkout
+            - run: git submodule update --init
+            - run: mkdir build
+            - run:
+                name: "Building tests ..."
+                working_directory: build
+                command: |
+                    cmake -DSTDLIB=libstdc++ \
+                          -DCMAKE_BUILD_TYPE=Release  ..
+            - run:
+                name: "Building tests ..."
+                working_directory: build
+                command: |
+                    make test-candas
+
+workflows:
+    version: 2
+    test-flow:
+        jobs:
+            - test-clang
+            - test-clang-libcxx
+            - test-gcc
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,27 @@ set(header_list
 
 # ================================================================================
 
+if((NOT STDLIB) AND (NOT STDLIB MATCHES ""))
+    set(STDLIB libstdc++)
+endif()
+
+# ----------------------------------------
+
 # compiler flags  --  mostly interresting for tests and examples
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++1z")  # common for all below
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -std=c++1z")
 # -----
 set(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -O0 -g -DDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -O2 -g -DDEBUG")
+# -----
+if($CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -stdlib=${STDLIB}")
+elseif($CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    # no special action to link againsd libstdc++ with g++
+    if(NOT ${STDLIB} MATCHES "libstdc++")
+        message(WARN "g++ is only configured to use 'libstdc++' as standard library")
+    endif()
+endif()
 
 # ================================================================================
 

--- a/contrib/dockerfiles/README.md
+++ b/contrib/dockerfiles/README.md
@@ -1,0 +1,57 @@
+
+Dockerfiles
+===========
+
+The subdirectories fo this directory contains the dockerfiles to build the test environments for
+Candas.
+
+ * `env-clang`: An environment with clang as the selected compiler.
+ * `env-clang-libcxx`: An environment with Clang as the compiler, where libc++ is available as
+    the standard library.
+ * `env-gcc`: An environment where gcc is the default compiler.
+
+Tests are run against the tags `clang`, `clang-libcxx`, and `gcc` on the dockerhub repository
+`candas/test-env`.
+
+## Build
+
+*Warning:* It takes a long time to build a images.
+
+*NB:* `env-clang` must be built before `env-clang-libcxx` as the latter depends upon the former.
+
+**Configuration:**
+
+ * `cmake_version`, `llvm_version`, and `gcc_version`: These variables determine the versions to
+    build.  The versions must match versions found on the respective download pages.
+ * `docker_build_cmd`: Change this the your favored docker build command. The most usefull change
+    is to change the number of CPUs used for the builds. E.g.: `--cpuset-cpus 1,2,3,4` wil build
+    using four cores.
+
+``` bash
+cmake_version=3.9.2
+llvm_version=5.0.0
+gcc_version=7.2.0
+
+docker_build_cmd="docker build --cpuset-cpus 1"
+
+# build core
+$docker_build_cmd \
+        -t candas/core:latest  core
+
+# build the clang testing environment
+$docker_build_cmd \
+        --build-arg cmake_ver=$cmake_version \
+        --build-arg clang_ver=$llvm_version \
+        -t candas/test-env:clang  env-clang
+
+# build the clang with libc++ testing environment
+$docker_build_cmd \
+        -t candas/test-env:clang-libcxx  env-clang-libcxx
+
+# build the gcc testing environment
+$docker_build_cmd \
+        --build-arg cmake_ver=$cmake_version \
+        --build-arg gcc_ver=$gcc_version \
+        -t candas/test-env:gcc  env-gcc
+```
+

--- a/contrib/dockerfiles/core/Dockerfile
+++ b/contrib/dockerfiles/core/Dockerfile
@@ -1,0 +1,13 @@
+
+FROM ubuntu:16.04
+LABEL maintainer="eivind@xal.no"
+
+RUN  apt-get --yes update \
+ &&  apt-get --yes install \
+        build-essential \
+        curl \
+        git \
+        python \
+        wget \
+ && apt-get --yes clean
+

--- a/contrib/dockerfiles/env-clang-libcxx/Dockerfile
+++ b/contrib/dockerfiles/env-clang-libcxx/Dockerfile
@@ -1,0 +1,14 @@
+
+FROM candas/test-env:clang
+LABEL maintainer="eivind@xal.no"
+
+# build
+ADD  build-steps-libcxx.sh  /
+RUN  bash build-steps-libcxx.sh $CLANG_VERSION \
+ &&  rm build-steps-libcxx.sh
+
+# set variables
+ENV  LIBCXX_VERSION=$CLANG_VERSION \
+     CC=clang \
+     CXX=clang++
+

--- a/contrib/dockerfiles/env-clang-libcxx/build-steps-libcxx.sh
+++ b/contrib/dockerfiles/env-clang-libcxx/build-steps-libcxx.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+function echo_run {
+    echo "EXECUTING :: $@"
+    "$@"
+    if [ $? != 0 ] ; then
+        echo "ERROR :: failed doing '$@'"
+        exit 1
+    fi
+}
+
+# abort if no version is given
+if [ -z "$1" ] ; then
+    echo "ERROR :: No version given"
+    exit 1
+fi
+
+# what version of CLANG to build
+# - must match a version found on `https://releases.llvm.org/`
+LIBCXX_VERSION="$1"
+
+# define paths
+DOWN_DIR=$HOME/down
+LLVM_SRC_HOME=$HOME/llvm-src
+LLVM_BUILD=$HOME/llvm-build
+
+# build in a shell procedure to use the same subshell for the entire build
+build_steps () {
+
+    # get prerequisites
+    echo_run  apt-get --yes update
+    echo_run  apt-get --yes install \
+                zlib1g-dev
+    echo_run  apt-get --yes clean
+
+    # download and check sources
+    echo_run  mkdir -p $DOWN_DIR && cd $DOWN_DIR
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key B6C8F98282B944E3B0D5C2530FC3042E345AD05D
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key 11E521D646982372EB577A1F8F0871F202119294
+    echo_run  curl  -O https://releases.llvm.org/$LIBCXX_VERSION/llvm-$LIBCXX_VERSION.src.tar.xz \
+                    -O https://releases.llvm.org/$LIBCXX_VERSION/llvm-$LIBCXX_VERSION.src.tar.xz.sig \
+                    -O https://releases.llvm.org/$LIBCXX_VERSION/libcxx-$LIBCXX_VERSION.src.tar.xz \
+                    -O https://releases.llvm.org/$LIBCXX_VERSION/libcxx-$LIBCXX_VERSION.src.tar.xz.sig \
+                    -O https://releases.llvm.org/$LIBCXX_VERSION/libcxxabi-$LIBCXX_VERSION.src.tar.xz \
+                    -O https://releases.llvm.org/$LIBCXX_VERSION/libcxxabi-$LIBCXX_VERSION.src.tar.xz.sig \
+                    -O https://releases.llvm.org/$LIBCXX_VERSION/libunwind-$LIBCXX_VERSION.src.tar.xz \
+                    -O https://releases.llvm.org/$LIBCXX_VERSION/libunwind-$LIBCXX_VERSION.src.tar.xz.sig
+    echo_run  gpg --no-options --verify llvm-$LIBCXX_VERSION.src.tar.xz.sig       llvm-$LIBCXX_VERSION.src.tar.xz
+    echo_run  gpg --no-options --verify libcxx-$LIBCXX_VERSION.src.tar.xz.sig     libcxx-$LIBCXX_VERSION.src.tar.xz
+    echo_run  gpg --no-options --verify libcxxabi-$LIBCXX_VERSION.src.tar.xz.sig  libcxxabi-$LIBCXX_VERSION.src.tar.xz
+    echo_run  gpg --no-options --verify libunwind-$LIBCXX_VERSION.src.tar.xz.sig  libunwind-$LIBCXX_VERSION.src.tar.xz
+
+    # setup sources
+    echo_run  tar --xz -xf llvm-$LIBCXX_VERSION.src.tar.xz
+    echo_run  tar --xz -xf libcxx-$LIBCXX_VERSION.src.tar.xz
+    echo_run  tar --xz -xf libcxxabi-$LIBCXX_VERSION.src.tar.xz
+    echo_run  tar --xz -xf libunwind-$LIBCXX_VERSION.src.tar.xz
+    echo_run  mv llvm-$LIBCXX_VERSION.src $LLVM_SRC_HOME
+    echo_run  mv libunwind-$LIBCXX_VERSION.src $LLVM_SRC_HOME/projects/libunwind
+    echo_run  mv libcxxabi-$LIBCXX_VERSION.src $LLVM_SRC_HOME/projects/libcxxabi
+    echo_run  mv libcxx-$LIBCXX_VERSION.src $LLVM_SRC_HOME/projects/libcxx
+
+    # run build
+    echo_run  mkdir -p $LLVM_BUILD && cd $LLVM_BUILD
+    echo_run  cmake \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DLIBCXXABI_USE_LLVM_UNWINDER=1 \
+                -DLIBCXX_HAS_GCC_S_LIB=0 \
+                $LLVM_SRC_HOME
+    echo_run  make -j$(nproc)
+    echo_run  make install
+    echo_run  ldconfig /usr/local/lib
+
+    # cleanup
+    echo_run  rm -rf $LLVM_SRC_HOME $LLVM_BUILD $DOWN_DIR
+    echo_run  apt-get --yes purge cmake
+    echo_run  apt-get --yes clean
+    echo_run  gpg --batch --delete-keys B6C8F98282B944E3B0D5C2530FC3042E345AD05D \
+                                        11E521D646982372EB577A1F8F0871F202119294
+
+}
+build_steps
+

--- a/contrib/dockerfiles/env-clang/Dockerfile
+++ b/contrib/dockerfiles/env-clang/Dockerfile
@@ -1,0 +1,21 @@
+
+FROM candas/core:latest
+LABEL maintainer="eivind@xal.no"
+
+# build arguments
+ARG  cmake_ver
+ARG  clang_ver
+
+# build
+ADD  build-steps-cmake.sh \
+     build-steps-clang.sh  /
+RUN  bash build-steps-cmake.sh ${cmake_ver} \
+ &&  bash build-steps-clang.sh ${clang_ver} \
+ &&  rm build-steps-cmake.sh build-steps-clang.sh
+
+# set variables
+ENV  CMAKE_VERSION=${cmake_ver} \
+     CLANG_VERSION=${clang_ver} \
+     CC=clang \
+     CXX=clang++
+

--- a/contrib/dockerfiles/env-clang/build-steps-clang.sh
+++ b/contrib/dockerfiles/env-clang/build-steps-clang.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+function echo_run {
+    echo "EXECUTING :: $@"
+    "$@"
+    if [ $? != 0 ] ; then
+        echo "ERROR :: failed doing '$@'"
+        exit 1
+    fi
+}
+
+# abort if no version is given
+if [ -z "$1" ] ; then
+    echo "ERROR :: No version given"
+    exit 1
+fi
+
+# what version of CLANG to build
+# - must match a version found on `https://releases.llvm.org/`
+CLANG_VERSION="$1"
+
+# define paths
+DOWN_DIR=$HOME/down
+LLVM_SRC_HOME=$HOME/llvm-src
+LLVM_BUILD=$HOME/llvm-build
+
+# build in a shell procedure to use the same subshell for the entire build
+build_steps () {
+
+    # get prerequisites
+    echo_run  apt-get --yes update
+    echo_run  apt-get --yes install \
+                zlib1g-dev
+    echo_run  apt-get --yes clean
+
+    # download and check sources
+    echo_run  mkdir -p $DOWN_DIR && cd $DOWN_DIR
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key B6C8F98282B944E3B0D5C2530FC3042E345AD05D
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key 11E521D646982372EB577A1F8F0871F202119294
+    echo_run  curl -O https://releases.llvm.org/$CLANG_VERSION/llvm-$CLANG_VERSION.src.tar.xz \
+                -O https://releases.llvm.org/$CLANG_VERSION/llvm-$CLANG_VERSION.src.tar.xz.sig \
+                -O https://releases.llvm.org/$CLANG_VERSION/cfe-$CLANG_VERSION.src.tar.xz \
+                -O https://releases.llvm.org/$CLANG_VERSION/cfe-$CLANG_VERSION.src.tar.xz.sig \
+                -O https://releases.llvm.org/$CLANG_VERSION/clang-tools-extra-$CLANG_VERSION.src.tar.xz \
+                -O https://releases.llvm.org/$CLANG_VERSION/clang-tools-extra-$CLANG_VERSION.src.tar.xz.sig \
+                -O https://releases.llvm.org/$CLANG_VERSION/compiler-rt-$CLANG_VERSION.src.tar.xz \
+                -O https://releases.llvm.org/$CLANG_VERSION/compiler-rt-$CLANG_VERSION.src.tar.xz.sig
+    echo_run  gpg --no-options --verify llvm-$CLANG_VERSION.src.tar.xz.sig              llvm-$CLANG_VERSION.src.tar.xz
+    echo_run  gpg --no-options --verify cfe-$CLANG_VERSION.src.tar.xz.sig               cfe-$CLANG_VERSION.src.tar.xz
+    echo_run  gpg --no-options --verify clang-tools-extra-$CLANG_VERSION.src.tar.xz.sig clang-tools-extra-$CLANG_VERSION.src.tar.xz
+    echo_run  gpg --no-options --verify compiler-rt-$CLANG_VERSION.src.tar.xz.sig       compiler-rt-$CLANG_VERSION.src.tar.xz
+
+    # setup sources
+    echo_run  tar --xz -xf llvm-$CLANG_VERSION.src.tar.xz
+    echo_run  tar --xz -xf cfe-$CLANG_VERSION.src.tar.xz
+    echo_run  tar --xz -xf clang-tools-extra-$CLANG_VERSION.src.tar.xz
+    echo_run  tar --xz -xf compiler-rt-$CLANG_VERSION.src.tar.xz
+    echo_run  mv llvm-$CLANG_VERSION.src $LLVM_SRC_HOME
+    echo_run  mv cfe-$CLANG_VERSION.src $LLVM_SRC_HOME/tools/clang
+    echo_run  mv clang-tools-extra-$CLANG_VERSION.src $LLVM_SRC_HOME/tools/clang/tools
+    echo_run  mv compiler-rt-$CLANG_VERSION.src $LLVM_SRC_HOME/projects/compiler-rt
+
+    # run build
+    echo_run  mkdir -p $LLVM_BUILD && cd $LLVM_BUILD
+    echo_run  cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release $LLVM_SRC_HOME
+    echo_run  make -j $(nproc)
+    echo_run  make install
+    echo_run  ldconfig /usr/local/lib
+
+    # cleanup
+    echo_run  rm -rf $LLVM_SRC_HOME $LLVM_BUILD $DOWN_DIR
+    echo_run  apt-get --yes purge cmake python
+    echo_run  apt-get --yes clean
+    echo_run  gpg --batch --delete-keys B6C8F98282B944E3B0D5C2530FC3042E345AD05D \
+                                        11E521D646982372EB577A1F8F0871F202119294
+
+}
+build_steps
+

--- a/contrib/dockerfiles/env-clang/build-steps-cmake.sh
+++ b/contrib/dockerfiles/env-clang/build-steps-cmake.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+function echo_run {
+    echo "EXECUTING :: $@"
+    "$@"
+    if [ $? != 0 ] ; then
+        echo "ERROR :: failed doing '$@'"
+        exit 1
+    fi
+}
+
+# abort if no version is given
+if [ -z "$1" ] ; then
+    echo "ERROR :: No version given"
+    exit 1
+fi
+
+# what version of CLANG to build
+# - must match a version found on `https://releases.llvm.org/`
+CMAKE_VERSION="$1"
+PATH_VER="$(echo $CMAKE_VERSION | sed -r s/\\.[0-9]+$//)"
+
+DOWN_DIR=$HOME/down
+CMAKE_SRC_DIR=$HOME/cmake-src
+
+# build in a shell procedure to use the same subshell for the entire build
+build_steps () {
+
+    # download and check
+    echo_run  mkdir -p $DOWN_DIR && cd $DOWN_DIR
+    echo_run  curl  -O https://cmake.org/files/v$PATH_VER/cmake-$CMAKE_VERSION.tar.gz \
+                    -O https://cmake.org/files/v$PATH_VER/cmake-$CMAKE_VERSION-SHA-256.txt
+    echo_run  sha256sum --ignore-missing -c cmake-$CMAKE_VERSION-SHA-256.txt
+    echo_run  tar xzf cmake-$CMAKE_VERSION.tar.gz
+    echo_run  mv cmake-$CMAKE_VERSION $CMAKE_SRC_DIR
+
+    # build
+    echo_run  cd $CMAKE_SRC_DIR
+    echo_run  ./bootstrap && make -j$(nproc) && make install
+
+    # cleanup
+    echo_run  cd $HOME
+    echo_run  rm -rf $DOWN_DIR $CMAKE_SRC_DIR
+
+}
+build_steps
+

--- a/contrib/dockerfiles/env-gcc/Dockerfile
+++ b/contrib/dockerfiles/env-gcc/Dockerfile
@@ -1,0 +1,21 @@
+
+FROM candas/core:latest
+LABEL maintainer="eivind@xal.no"
+
+# build arguments
+ARG  cmake_ver
+ARG  gcc_ver
+
+# build
+ADD  build-steps-cmake.sh \
+     build-steps-gcc.sh  /
+RUN  bash build-steps-cmake.sh ${cmake_ver} \
+ &&  bash build-steps-gcc.sh ${gcc_ver} \
+ &&  rm build-steps-cmake.sh build-steps-gcc.sh
+
+# set variables
+ENV  CMAKE_VERSION=${cmake_ver} \
+     GCC_VERSION=${gcc_ver} \
+     CC=gcc \
+     CXX=g++
+

--- a/contrib/dockerfiles/env-gcc/build-steps-cmake.sh
+++ b/contrib/dockerfiles/env-gcc/build-steps-cmake.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+function echo_run {
+    echo "EXECUTING :: $@"
+    "$@"
+    if [ $? != 0 ] ; then
+        echo "ERROR :: failed doing '$@'"
+        exit 1
+    fi
+}
+
+# abort if no version is given
+if [ -z "$1" ] ; then
+    echo "ERROR :: No version given"
+    exit 1
+fi
+
+# what version of CLANG to build
+# - must match a version found on `https://releases.llvm.org/`
+CMAKE_VERSION="$1"
+PATH_VER="$(echo $CMAKE_VERSION | sed -r s/\\.[0-9]+$//)"
+
+DOWN_DIR=$HOME/down
+CMAKE_SRC_DIR=$HOME/cmake-src
+
+# build in a shell procedure to use the same subshell for the entire build
+build_steps () {
+
+    # download and check
+    echo_run  mkdir -p $DOWN_DIR && cd $DOWN_DIR
+    echo_run  curl  -O https://cmake.org/files/v$PATH_VER/cmake-$CMAKE_VERSION.tar.gz \
+                    -O https://cmake.org/files/v$PATH_VER/cmake-$CMAKE_VERSION-SHA-256.txt
+    echo_run  sha256sum --ignore-missing -c cmake-$CMAKE_VERSION-SHA-256.txt
+    echo_run  tar xzf cmake-$CMAKE_VERSION.tar.gz
+    echo_run  mv cmake-$CMAKE_VERSION $CMAKE_SRC_DIR
+
+    # build
+    echo_run  cd $CMAKE_SRC_DIR
+    echo_run  ./bootstrap && make -j$(nproc) && make install
+
+    # cleanup
+    echo_run  cd $HOME
+    echo_run  rm -rf $DOWN_DIR $CMAKE_SRC_DIR
+
+}
+build_steps
+

--- a/contrib/dockerfiles/env-gcc/build-steps-gcc.sh
+++ b/contrib/dockerfiles/env-gcc/build-steps-gcc.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+function echo_run {
+    echo "EXECUTING :: $@"
+    "$@"
+    if [ $? != 0 ] ; then
+        echo "ERROR :: failed doing '$@'"
+        exit 1
+    fi
+}
+
+# abort if no version is given
+if [ -z "$1" ] ; then
+    echo "ERROR :: No version given"
+    exit 1
+fi
+
+# what version of GCC to build
+# - must match a version found on `ftp://ftp.gnu.org/gnu/gcc`
+GCC_VERSION="$1"
+
+# define paths
+DOWN_DIR=$HOME/down
+GCC_SRC_DIR=$HOME/gcc-src
+GCC_BUILD_DIR=$HOME/build-gcc
+
+# build in a shell procedure to use the same subshell for the entire build
+build_steps () {
+
+    # get prerequisites
+    echo_run  apt-get --yes update
+    echo_run  apt-get --yes install \
+                libc6-dev
+    echo_run  apt-get --yes clean
+
+    # get public keys
+    # - 1024D/745C015A 1999-11-09 Gerald Pfeifer <gerald@pfeifer.com>
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key B215C1633BCA0477615F1B35A5B3A004745C015A
+    # - 1024D/B75C61B8 2003-04-10 Mark Mitchell <mark@codesourcery.com>
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key B3C42148A44E6983B3E4CC0793FA9B1AB75C61B8
+    # - 1024D/902C9419 2004-12-06 Gabriel Dos Reis <gdr@acm.org>
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key 90AA470469D3965A87A5DCB494D03953902C9419
+    # - 1024D/F71EDF1C 2000-02-13 Joseph Samuel Myers <jsm@polyomino.org.uk>
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key 80F98B2E0DAB6C8281BDF541A7C8C3B2F71EDF1C
+    # - 2048R/FC26A641 2005-09-13 Richard Guenther <richard.guenther@gmail.com>
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key 7F74F97C103468EE5D750B583AB00996FC26A641
+    # - 1024D/C3C45C06 2004-04-21 Jakub Jelinek <jakub@redhat.com>
+    echo_run  gpg --batch --keyserver pgp.key-server.io --recv-key 33C235A34C46AA3FFB293709A328C3A2C3C45C06
+
+    # download and check sources
+    echo_run  mkdir -p $DOWN_DIR && cd $DOWN_DIR
+    echo_run  curl  -O ftp://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz \
+                    -O ftp://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz.sig
+    echo_run  gpg --batch --verify gcc-$GCC_VERSION.tar.gz.sig gcc-$GCC_VERSION.tar.gz
+    echo_run  tar --gzip -xf gcc-$GCC_VERSION.tar.gz
+    echo_run  mv gcc-$GCC_VERSION $GCC_SRC_DIR
+
+    # build
+    echo_run  cd $GCC_SRC_DIR
+    echo_run  ./contrib/download_prerequisites
+    echo_run  mkdir -p $GCC_BUILD_DIR && cd $GCC_BUILD_DIR
+    echo_run  $GCC_SRC_DIR/configure --enable-languages=all \
+                                     --enable-shared \
+                                     --enable-threads=posix \
+                                     --enable-_cxa_atexit \
+                                     --enable-clocale=gnu \
+                                     --disable-multilib
+    echo_run  make -j$(nproc)
+    echo_run  make install
+    echo_run  ldconfig /usr/local/lib
+
+    # cleanup
+    echo_run  cd $HOME
+    echo_run  rm -rf $DOWN_DIR $GCC_SRC_DIR $GCC_BUILD_DIR
+    echo_run  gpg --batch --delete-keys B215C1633BCA0477615F1B35A5B3A004745C015A \
+                                        B3C42148A44E6983B3E4CC0793FA9B1AB75C61B8 \
+                                        90AA470469D3965A87A5DCB494D03953902C9419 \
+                                        80F98B2E0DAB6C8281BDF541A7C8C3B2F71EDF1C \
+                                        7F74F97C103468EE5D750B583AB00996FC26A641 \
+                                        33C235A34C46AA3FFB293709A328C3A2C3C45C06
+
+}
+build_steps
+


### PR DESCRIPTION
This PR adds a configuration file for CircleCI to run the project tests against gcc, Clang, and Clang with libc++.

Files to build the docker images used by CircleCI is included in contrib/dockerfiles, along with a decription of how to build the images.

-----

The docker images is hosted on dockerhub under the [candas organization](https://hub.docker.com/u/candas/dashboard/). If anyone else would like push access there send me a message.